### PR TITLE
Cochran Test (breaking change)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labkar-algorithms",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "Labkar Algorithms",
   "main": "dist/lib.js",
   "author": "ODTÜ PAL",

--- a/src/algorithms/cochran.ts
+++ b/src/algorithms/cochran.ts
@@ -1,53 +1,57 @@
 import { get } from 'lodash';
 import { CochranResult } from '../types';
-import { standardDeviation } from 'simple-statistics';
+import { sampleStandardDeviation } from 'simple-statistics';
 import cochranCriticalValues from './cochranCriticalValues';
 
-export function Cochran(values: Array<number[]>): CochranResult | null {
+export function Cochran(
+  values: Array<number[]>,
+  options: { alpha: number } = { alpha: 0.05 }
+): CochranResult | null {
   /* p -> numune sayısı  */
   const pValue = values.length;
 
   /* n -> yapılan tekrar,test sayısı */
   const nValue = values[0].length;
 
-  const onePercentCriticalValue = get(
-    cochranCriticalValues,
-    `${nValue}.1%.${pValue}`
-  );
+  const criticalValueKey =
+    options.alpha === 0.05
+      ? `${nValue}.5%.${pValue}`
+      : `${nValue}.1%.${pValue}`;
 
-  const fivePercentCriticalValue = get(
-    cochranCriticalValues,
-    `${nValue}.5%.${pValue}`
-  );
+  const criticalValue = get(cochranCriticalValues, criticalValueKey);
 
-  if (!onePercentCriticalValue || !fivePercentCriticalValue) {
+  if (!criticalValue) {
     return null;
   }
 
   const squareDeviations = values
-    .map((value) => {
-      return standardDeviation(value);
-    })
-    .map((value) => {
-      return value * value;
-    });
+    .map((pair: number[]) => sampleStandardDeviation(pair))
+    .map((sd: number) => sd * sd);
 
   const maxDeviation = Math.max.apply(null, squareDeviations);
   const sumOfSquareDeviations = squareDeviations.reduce((a, b) => a + b, 0);
 
+  // These are the values used to calculate max deviation
+  const cPairIndex = squareDeviations.indexOf(maxDeviation);
+  const cPair = values[squareDeviations.indexOf(maxDeviation)];
+
   const cValue = maxDeviation / sumOfSquareDeviations;
 
-  if (cValue < fivePercentCriticalValue) {
-    return CochranResult.Correct;
+  if (cValue < criticalValue) {
+    return {
+      outlier: false,
+      cValue,
+      cPair,
+      cPairIndex: cPairIndex,
+      maxDeviation,
+    };
   }
 
-  if (cValue < onePercentCriticalValue && cValue > fivePercentCriticalValue) {
-    return CochranResult.Straggler;
-  }
-
-  if (cValue > onePercentCriticalValue) {
-    return CochranResult.Outlier;
-  }
-
-  return null;
+  return {
+    outlier: true,
+    cValue,
+    cPair,
+    cPairIndex,
+    maxDeviation,
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,25 @@ export type AResult = {
   lowLimit: number;
 };
 
-export enum CochranResult {
-  Outlier = 'outlier',
-  Straggler = 'straggler',
-  Correct = 'correct',
-}
+export type CochranResult = {
+  outlier: boolean;
+  /**
+   * Value used to compare to the elected critical value
+   */
+  cValue: number;
+  /**
+   * The pair used to calculate the max deviation
+   */
+  cPair: number[];
+  /**
+   * Index of the pair used to calculate the max deviation
+   */
+  cPairIndex: number;
+  /**
+   * Maximum value among (stdDev(pair) ^ 2)
+   */
+  maxDeviation: number;
+};
 
 export type ReferenceResult = {
   value: number;

--- a/tests/cochran.test.ts
+++ b/tests/cochran.test.ts
@@ -1,5 +1,4 @@
 import { Cochran } from '../src/lib';
-import { CochranResult } from '../src/types';
 
 describe('Cochran Algorithm', () => {
   it('Cochran Algorithm Test (Outlier)', () => {
@@ -21,21 +20,35 @@ describe('Cochran Algorithm', () => {
       [88.8, 85],
     ];
 
-    const output = Cochran(samples);
-    expect(output).toBe(CochranResult.Outlier);
+    let output = Cochran(samples, { alpha: 0.05 });
+    expect(output?.maxDeviation).toBeCloseTo(31.205, 3);
+    expect(output?.cPairIndex).toBe(11);
+    expect(output?.cPair).toEqual([91, 83.1]);
+    expect(output?.outlier).toBe(true);
+
+    output = Cochran(samples, { alpha: 0.01 });
+    expect(output?.outlier).toBe(true);
   });
 
-  it('Cochran Algorithm Test (Correct)', () => {
+  it.only('Cochran Algorithm Test (Straggler)', () => {
     const samples = [
-      [73, 45],
-      [22, 26],
-      [12, 42],
-      [42, 20],
-      [21, 30],
+      [9.9, 10.2],
+      [10.4, 9.5],
+      [10, 10],
+      [10, 10],
+      [10.2, 10.3],
+      [9.5, 9.9],
+      [10.5, 10.1],
+      [10.1, 10.3],
+      [10, 10.1],
+      [10.2, 10],
     ];
 
-    const output = Cochran(samples);
-    expect(output).toBe(CochranResult.Correct);
+    let output = Cochran(samples);
+    expect(output?.outlier).toBe(true);
+
+    output = Cochran(samples, { alpha: 0.01 });
+    expect(output?.outlier).toBe(false);
   });
 
   it('Cochran Algorithm Test (Null)', () => {


### PR DESCRIPTION
- Cochran test now uses sample standard deviation
- It only works with one critical value (1% or 5%) at a time. This can be provided in the options parameter as `{alpha: 0.01}` or `{alpha: 0.05}`. The default critical value is `{alpha: 0.05}` or 5%