### PR TITLE
Fix failing cochran

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "labkar-algorithms",
-  "version": "4.0.0",
+  "version": "5.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "labkar-algorithms",
-      "version": "4.0.0",
+      "version": "5.3.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "jstat": "^1.9.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labkar-algorithms",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "Labkar Algorithms",
   "main": "dist/lib.js",
   "author": "ODTÜ PAL",

--- a/src/algorithms/cochran.ts
+++ b/src/algorithms/cochran.ts
@@ -7,12 +7,24 @@ type CochranOptions = {
   alpha: number;
   originalIndexes?: number[];
   outlierIndexes?: number[];
-}
+};
 
 export function Cochran(
   values: Array<number[]>,
   options: CochranOptions = { alpha: 0.05 }
 ): CochranResult | null {
+  // Early return if all values are identical
+  const allIdentical = values.every(
+    (sample) =>
+      sample.every((value) => value === sample[0]) && sample[0] === values[0][0]
+  );
+
+  if (allIdentical) {
+    return {
+      outlierIndexes: [],
+      hasOutliers: false,
+    };
+  }
 
   // Keep track of original indexes of values at the beginning
   // When we return indexes of outliers, this will be useful.
@@ -67,7 +79,7 @@ export function Cochran(
     {
       alpha: options.alpha,
       originalIndexes,
-      outlierIndexes
+      outlierIndexes,
     }
-  )
+  );
 }

--- a/tests/algorithms.test.ts
+++ b/tests/algorithms.test.ts
@@ -63,7 +63,7 @@ describe('Algorithms', () => {
     // expect(output.hampel).toBeCloseTo(44.722, 3);
   });
 
-  it.skip('Q/Hampel Method (samples with no variance)', () => {
+  it('Q/Hampel Method (samples with no variance)', () => {
     const samples = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
 
     const q = Q(samples);

--- a/tests/cochran.test.ts
+++ b/tests/cochran.test.ts
@@ -76,4 +76,19 @@ describe('Cochran Algorithm', () => {
     expect(output?.outlierIndexes).toContain(0);
     expect(output?.outlierIndexes).toContain(5);
   })
+
+  it('Cochran Algorithm Test (New Values)', () => {
+    const samples = [
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+    ];
+
+    const output = Cochran(samples);
+    expect(output?.hasOutliers).toBe(false); // Adjust the expectation based on your algorithm's behavior
+  });
 });

--- a/tests/cochran.test.ts
+++ b/tests/cochran.test.ts
@@ -58,7 +58,6 @@ describe('Cochran Algorithm', () => {
   });
 
   it('Repeats test until there are no outliers', () => {
-
     const samples = [
       [0.135, 0.194], // index=0 = outlier
       [0.187, 0.189],
@@ -70,12 +69,27 @@ describe('Cochran Algorithm', () => {
       [0.177, 0.186],
       [0.179, 0.187],
       [0.188, 0.196],
-    ]
+    ];
 
     const output = Cochran(samples, { alpha: 0.01 });
     expect(output?.outlierIndexes).toContain(0);
     expect(output?.outlierIndexes).toContain(5);
-  })
+  });
+
+  it('Cochran Algorithm Test (New Values)', () => {
+    const samples = [
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+    ];
+
+    const output = Cochran(samples);
+    expect(output?.hasOutliers).toBe(false); // Adjust the expectation based on your algorithm's behavior
+  });
 
   it('Cochran Algorithm Test (New Values)', () => {
     const samples = [


### PR DESCRIPTION
Ensure that Cochran test still works even if all values are identical. ([1,1], [1,1], ...)